### PR TITLE
Feat/report prototype : feat: report_v0 + downloads index + ADR

### DIFF
--- a/docs/ADR-001-report-export.md
+++ b/docs/ADR-001-report-export.md
@@ -1,0 +1,15 @@
+# ADR-001 — Report export approach (static PNG in PDF)
+
+## Context
+Our report must show (a) table of evidence [SSID, BSSID (hashed), enc, band, channel, RSSI, timestamp], (b) static heatmap image, (c) parameters/filters used, (d) audit footer.
+
+## Options
+A) Programmatic PDF (Python PDF libs): deterministic layout, reliable image placement; slower to style.  
+B) HTML/CSS → PDF (print a page): fast to iterate; interactive maps (Folium/JS) don’t render to PDF, so we must export PNG first.
+
+## Decision (MVP)
+Use **static PNG heatmaps embedded in a deterministic PDF** (or a printed static HTML) for auditability and portability. Interactive maps remain for the web demo.
+
+## Consequences
+- Export pipeline is reproducible across machines.
+- We keep a small, fixed footer: “MACs pseudonymised; data captured under written permission; see Minutes 2025-09-01.”

--- a/docs/data/mock_scans.csv
+++ b/docs/data/mock_scans.csv
@@ -1,0 +1,4 @@
+ssid,bssid_hash,enc,band,channel,rssi,ts,lat,lon,anchor_id
+UTS_Guest,7ff98a...,WPA2,2.4,6,-62,2025-08-15T10:37:21Z,,,
+UTS_Staff,31aa02...,WPA2,5,44,-71,2025-08-15T10:38:10Z,-33.883,151.200,
+UTS_Guest,7ff98a...,WPA2,2.4,6,-57,2025-08-15T10:39:05Z,,,-A1

--- a/docs/docs/acceptance-criteria-v1.md
+++ b/docs/docs/acceptance-criteria-v1.md
@@ -1,0 +1,12 @@
+## Role #4 — Automated report maker
+R4-1 Columns: SSID, BSSID (hashed), Enc, Band, Channel, RSSI, Timestamp (+ optional GPS/anchor)  
+R4-2 Footer: “MACs pseudonymised; data captured under written permission; see Minutes YYYY-MM-DD.”  
+R4-3 Heatmap: Static PNG only (no interactive map in PDF)  
+R4-4 Parameters block lists filters/time range  
+R4-5 Prototype target: PDF ≤ 4 MB (2–5k rows); export time noted
+
+## Role #2 — Web UI to download files
+R2-1 Filenames: `report_<SSID>_<YYYYMMDD-HHMM>_<filters>.pdf`  
+R2-2 Downloads view lists name, size, created time  
+R2-3 Clicking link opens/downloads successfully  
+R2-4 Evidence: screenshot with 2–3 files listed

--- a/docs/prototypes/downloads_index.html
+++ b/docs/prototypes/downloads_index.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html><head><meta charset="utf-8"><title>Downloads — Wi-Fi Analytics (prototype)</title>
+<style>body{font-family:system-ui,Arial;margin:24px} table{border-collapse:collapse;width:100%} th,td{border:1px solid #ddd;padding:8px}</style>
+</head><body>
+<h1>Downloads</h1>
+<table>
+<thead><tr><th>File</th><th>Description</th></tr></thead>
+<tbody>
+<tr><td><a href="report_v0.html">report_v0.html</a></td><td>Static report mock (print to PDF for submission)</td></tr>
+<tr><td><a href="../data/mock_scans.csv">mock_scans.csv</a></td><td>Sample evidence rows</td></tr>
+<tr><td><a href="../images/heatmap_dummy.png">heatmap_dummy.png</a></td><td>Placeholder static heatmap</td></tr>
+</tbody>
+</table>
+</body></html>

--- a/prototypes/report_v0.html
+++ b/prototypes/report_v0.html
@@ -1,0 +1,43 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Wi-Fi Analytics — Report v0 (prototype)</title>
+  <style>
+    body { font-family: system-ui, Arial, sans-serif; margin: 24px; }
+    h1,h2 { margin: 0 0 8px; }
+    .meta, footer { font-size: 12px; color: #444; }
+    table { border-collapse: collapse; width: 100%; margin-top: 12px; }
+    th, td { border: 1px solid #ddd; padding: 6px 8px; font-size: 14px; }
+    th { background: #f3f5f7; text-align: left; }
+    .params { margin: 8px 0 12px; }
+    .heatmap { margin: 12px 0; border: 1px dashed #bbb; padding: 8px; text-align:center; }
+  </style>
+</head>
+<body>
+  <h1>Wi-Fi Analytics — Report v0</h1>
+  <div class="meta">Generated: 2025-08-22 11:30 • Dataset: mock_scans.csv</div>
+
+  <div class="params"><strong>Parameters:</strong> SSID=UTS_* • Band=2.4/5 • Time=2025-08-15</div>
+
+  <h2>Evidence (sample rows)</h2>
+  <table>
+    <thead>
+      <tr><th>SSID</th><th>BSSID (hashed)</th><th>Enc</th><th>Band</th><th>Ch</th><th>RSSI</th><th>Timestamp</th></tr>
+    </thead>
+    <tbody>
+      <tr><td>UTS_Guest</td><td>7ff98a…</td><td>WPA2</td><td>2.4</td><td>6</td><td>-62</td><td>2025-08-15T10:37:21Z</td></tr>
+      <tr><td>UTS_Staff</td><td>31aa02…</td><td>WPA2</td><td>5</td><td>44</td><td>-71</td><td>2025-08-15T10:38:10Z</td></tr>
+    </tbody>
+  </table>
+
+  <div class="heatmap">
+    <em>Heatmap PNG placeholder</em><br>
+    <img src="../images/heatmap_dummy.png" alt="heatmap" style="max-width:100%;height:auto;">
+  </div>
+
+  <footer>
+    MACs pseudonymised; data captured under written permission. See Minutes 2025-08-05.
+  </footer>
+</body>
+</html>


### PR DESCRIPTION
## docs/acceptance-criteria-v1.md
## Role #4 — Automated report maker
R4-1 Columns: SSID, BSSID (hashed), Enc, Band, Channel, RSSI, Timestamp (+ optional GPS/anchor)  
R4-2 Footer: “MACs pseudonymised; data captured under written permission; see Minutes YYYY-MM-DD.”  
R4-3 Heatmap: Static PNG only (no interactive map in PDF)  
R4-4 Parameters block lists filters/time range  
R4-5 Prototype target: PDF ≤ 4 MB (2–5k rows); export time noted

## Role #2 — Web UI to download files
R2-1 Filenames: `report_<SSID>_<YYYYMMDD-HHMM>_<filters>.pdf`  
R2-2 Downloads view lists name, size, created time  
R2-3 Clicking link opens/downloads successfully  
R2-4 Evidence: screenshot with 2–3 files listed
